### PR TITLE
Enable custom usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ README.md
 
 A simple real-time chat application built with Node.js, Socket.IO, and React.
 The project is split into a `server` folder containing the Socket.IO backend
-and a `client` folder with the React interface.
+and a `client` folder with the React interface. You can now set a custom
+display name directly in the chat UI.
 
 ## Getting Started
 

--- a/client/src/components/Chat.js
+++ b/client/src/components/Chat.js
@@ -7,6 +7,7 @@ const socket = io('http://localhost:4000');
 function Chat() {
   const [message, setMessage] = useState('');
   const [chat, setChat] = useState([]);
+  const [username, setUsername] = useState('User');
 
   useEffect(() => {
     socket.emit('joinRoom', 'general');
@@ -21,13 +22,21 @@ function Chat() {
   const sendChat = (e) => {
     e.preventDefault();
     if (!message.trim()) return;
-    socket.emit('chatMessage', { room: 'general', author: 'User', message });
+    socket.emit('chatMessage', { room: 'general', author: username || 'User', message });
     setMessage('');
   };
 
   return (
     <div style={{ maxWidth: '600px', margin: '0 auto' }}>
       <h2>QuickChat – General Room</h2>
+      <div style={{ marginBottom: '1rem' }}>
+        <input
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Enter your name"
+          style={{ width: '40%', padding: '.5rem' }}
+        />
+      </div>
       <div
         style={{
           border: '1px solid #ccc',


### PR DESCRIPTION
## Summary
- allow users to set their name in the chat component
- document the new feature in the README

## Testing
- `npm test` (fails: missing script)
- `npm test` in server (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_688c7da61a8c83289dde437a75560283