### PR TITLE
feat: add multi-room chat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,13 @@ README.md
 
 A simple real-time chat application built with Node.js, Socket.IO, and React.
 The project is split into a `server` folder containing the Socket.IO backend
-and a `client` folder with the React interface. You can now set a custom
-display name directly in the chat UI.
+and a `client` folder with the React interface. You can set a custom display
+name directly in the chat UI and create or join arbitrary chat rooms.
+
+## Features
+- Real-time messaging with Socket.IO
+- Customizable display names
+- Join or create separate chat rooms on the fly
 
 ## Getting Started
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,3 @@
-//// client/src/App.js
 import Chat from './components/Chat';
 
 function App() {

--- a/client/src/components/Chat.js
+++ b/client/src/components/Chat.js
@@ -1,4 +1,3 @@
-//// client/src/components/Chat.js
 import React, { useState, useEffect } from 'react';
 import io from 'socket.io-client';
 
@@ -8,34 +7,55 @@ function Chat() {
   const [message, setMessage] = useState('');
   const [chat, setChat] = useState([]);
   const [username, setUsername] = useState('User');
+  const [room, setRoom] = useState('general');
+  const [roomInput, setRoomInput] = useState('general');
 
   useEffect(() => {
-    socket.emit('joinRoom', 'general');
-
-    socket.on('chatMessage', ({ author, message, timestamp }) => {
-      setChat(prev => [...prev, { author, message, timestamp }]);
-    });
-
-    return () => socket.disconnect();
+    const handleMessage = ({ author, message, timestamp }) => {
+      setChat((prev) => [...prev, { author, message, timestamp }]);
+    };
+    socket.on('chatMessage', handleMessage);
+    return () => {
+      socket.off('chatMessage', handleMessage);
+      socket.disconnect();
+    };
   }, []);
+
+  useEffect(() => {
+    socket.emit('joinRoom', room);
+    setChat([]);
+  }, [room]);
 
   const sendChat = (e) => {
     e.preventDefault();
     if (!message.trim()) return;
-    socket.emit('chatMessage', { room: 'general', author: username || 'User', message });
+    socket.emit('chatMessage', { room, author: username || 'User', message });
     setMessage('');
   };
 
   return (
     <div style={{ maxWidth: '600px', margin: '0 auto' }}>
-      <h2>QuickChat – General Room</h2>
+      <h2>QuickChat – {room} Room</h2>
       <div style={{ marginBottom: '1rem' }}>
         <input
           value={username}
           onChange={(e) => setUsername(e.target.value)}
           placeholder="Enter your name"
-          style={{ width: '40%', padding: '.5rem' }}
+          style={{ width: '40%', padding: '.5rem', marginRight: '.5rem' }}
         />
+        <input
+          value={roomInput}
+          onChange={(e) => setRoomInput(e.target.value)}
+          placeholder="Room"
+          style={{ width: '30%', padding: '.5rem', marginRight: '.5rem' }}
+        />
+        <button
+          type="button"
+          onClick={() => setRoom(roomInput || 'general')}
+          style={{ padding: '.5rem 1rem' }}
+        >
+          Join
+        </button>
       </div>
       <div
         style={{

--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,12 @@ io.on('connection', (socket) => {
   console.log('User connected');
 
   socket.on('joinRoom', (room) => {
+    // Ensure the client leaves any previously joined rooms
+    for (const joinedRoom of socket.rooms) {
+      if (joinedRoom !== socket.id) {
+        socket.leave(joinedRoom);
+      }
+    }
     socket.join(room);
   });
 


### PR DESCRIPTION
## Summary
- allow users to join or create custom rooms from the chat UI
- ensure server leaves previous rooms when joining a new one
- document new multi-room capability

## Testing
- `cd server && npm test` *(fails: Missing script: "test")*
- `cd client && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689452e8a7788328ac594a9a4f0dab21