### PR TITLE
Avoid disconnecting socket when Chat unmounts

### DIFF
--- a/client/src/components/Chat.js
+++ b/client/src/components/Chat.js
@@ -17,7 +17,6 @@ function Chat() {
     socket.on('chatMessage', handleMessage);
     return () => {
       socket.off('chatMessage', handleMessage);
-      socket.disconnect();
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- Keep Socket.IO connection open when the Chat component unmounts to prevent unexpected disconnects

## Testing
- `npm test` (client) *(fails: Missing script "test")*
- `npm test` (server) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a85dd3ea883289363920bb8cb559b